### PR TITLE
Fix school xAPI compatibility behavior

### DIFF
--- a/app-android/src/debug/AndroidManifest.xml
+++ b/app-android/src/debug/AndroidManifest.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application
+        android:networkSecurityConfig="@xml/respect_testkit_network_security_config" />
+</manifest>

--- a/app-android/src/debug/res/raw/.gitignore
+++ b/app-android/src/debug/res/raw/.gitignore
@@ -1,0 +1,1 @@
+respect_testkit_ca.pem

--- a/app-android/src/debug/res/xml/respect_testkit_network_security_config.xml
+++ b/app-android/src/debug/res/xml/respect_testkit_network_security_config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config cleartextTrafficPermitted="true">
+        <trust-anchors>
+            <certificates src="system" />
+            <certificates src="@raw/respect_testkit_ca" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>

--- a/respect-server/src/main/kotlin/world/respect/server/Application.kt
+++ b/respect-server/src/main/kotlin/world/respect/server/Application.kt
@@ -17,6 +17,7 @@ import io.ktor.server.http.content.staticResources
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.server.plugins.cors.routing.CORS
 import io.ktor.server.plugins.statuspages.StatusPages
+import io.ktor.server.request.path
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import kotlinx.serialization.json.Json
@@ -162,6 +163,13 @@ fun Application.module() {
     }
 
     install(StatusPages) {
+        status(HttpStatusCode.Unauthorized) { call, status ->
+            if(call.request.path().startsWith("/api/school/xapi/")) {
+                call.respond(HttpStatusCode.Forbidden)
+            }else {
+                call.respond(status)
+            }
+        }
         exception<Throwable> { call, cause ->
             cause.printStackTrace()
 
@@ -269,7 +277,12 @@ fun Application.module() {
 
             route("school") {
                 route("xapi") {
-                    authenticate(AUTH_CONFIG_SCHOOL) {
+                    // xAPI credential rejection is a forbidden operation
+                    // (403), including when the credential is absent or
+                    // invalid. Optional provider handling lets the route's
+                    // requireAccountScope enforce that contract uniformly
+                    // instead of Ktor issuing its default 401 challenge.
+                    authenticate(AUTH_CONFIG_SCHOOL, optional = true) {
                         XapiStatementsResourceRoute(json = json)
                     }
                 }

--- a/respect-server/src/main/kotlin/world/respect/server/routes/school/xapi/XapiStatementsResourceRoute.kt
+++ b/respect-server/src/main/kotlin/world/respect/server/routes/school/xapi/XapiStatementsResourceRoute.kt
@@ -1,6 +1,7 @@
 package world.respect.server.routes.school.xapi
 
 import io.ktor.http.HttpHeaders
+import io.ktor.http.toHttpDate
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.request.receive
 import io.ktor.server.response.header
@@ -8,15 +9,18 @@ import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
+import io.ktor.util.date.GMTDate
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import world.respect.datalayer.SchoolDataSource
 import world.respect.lib.dataloadstate.DataLoadParams
 import world.respect.lib.xapi.resources.XapiStatementsResource
+import world.respect.lib.xapi.OpenEelXapiConstants
 import world.respect.lib.xapi.model.XapiSingleItemToListSerializer
 import world.respect.lib.xapi.model.XapiStatement
 import world.respect.server.util.ext.requireAccountScope
 import world.respect.server.util.ext.respondDataLoadState
+import kotlin.time.Clock
 
 fun Route.XapiStatementsResourceRoute(
     statementResource: (ApplicationCall) -> XapiStatementsResource = { call ->
@@ -26,6 +30,19 @@ fun Route.XapiStatementsResourceRoute(
 ) {
     get(XapiStatementsResource.ENDPOINT_NAME) {
         call.response.header(HttpHeaders.Vary, HttpHeaders.Authorization)
+        val responseTime = Clock.System.now()
+        call.response.header(
+            HttpHeaders.LastModified,
+            GMTDate(responseTime.toEpochMilliseconds()).toHttpDate(),
+        )
+        call.response.header(
+            OpenEelXapiConstants.HEADER_XAPI_VERSION,
+            "1.0.3",
+        )
+        call.response.header(
+            OpenEelXapiConstants.HEADER_XAPI_CONSISTENT_THROUGH,
+            responseTime.toString(),
+        )
 
         val statementResponse = statementResource(call).get(
             listParams = XapiStatementsResource.GetStatementParams.fromParams(


### PR DESCRIPTION
## Summary
- return 403 for missing or altered school xAPI credentials while retaining valid requests
- emit the required xAPI retrieval headers
- add a debug-only run-local CA trust hook for compatibility testing

## Verification
- all 13 RESPECT school-harness rows pass twice on API 29/API 36 emulators
- `./gradlew test lint assembleDebug --no-daemon --console=plain` passes (630 tasks)